### PR TITLE
fix: self-compare excludes launcher PID from benchmark gate

### DIFF
--- a/src/bin/zenbench.rs
+++ b/src/bin/zenbench.rs
@@ -763,6 +763,16 @@ fn run_bench_in_dir(
         .args(["bench", "--bench", bench_name])
         .env("ZENBENCH_RESULT_PATH", result_path);
 
+    // Tell the child benchmark to exclude the launcher's PID from the
+    // benchmark-process gate. Without this, the child detects the parent
+    // `zenbench self-compare` process and waits for it to exit (deadlock).
+    let our_pid = std::process::id();
+    let launcher_pids = match std::env::var("ZENBENCH_LAUNCHER_PIDS") {
+        Ok(existing) => format!("{existing},{our_pid}"),
+        Err(_) => our_pid.to_string(),
+    };
+    cmd.env("ZENBENCH_LAUNCHER_PIDS", &launcher_pids);
+
     if let Some(args) = cargo_args {
         for arg in args.split_whitespace() {
             cmd.arg(arg);

--- a/src/gate.rs
+++ b/src/gate.rs
@@ -256,6 +256,22 @@ impl ResourceGate {
         const BENCH_NAMES: &[&str] = &["criterion", "divan", "zenbench", "cargo-bench", "bench-"];
 
         let our_pid = sysinfo::get_current_pid().ok();
+
+        // Collect PIDs to exclude: ourselves, plus any launcher PIDs.
+        // `zenbench self-compare` sets ZENBENCH_LAUNCHER_PIDS so the child
+        // benchmark doesn't wait on its own parent CLI process.
+        let mut excluded_pids: Vec<sysinfo::Pid> = Vec::new();
+        if let Some(our) = our_pid {
+            excluded_pids.push(our);
+        }
+        if let Ok(pids_str) = std::env::var("ZENBENCH_LAUNCHER_PIDS") {
+            for s in pids_str.split(',') {
+                if let Ok(pid) = s.trim().parse::<usize>() {
+                    excluded_pids.push(sysinfo::Pid::from(pid));
+                }
+            }
+        }
+
         let start = Instant::now();
         let max_wait = Duration::from_secs(30);
         let mut warned = false;
@@ -270,11 +286,9 @@ impl ResourceGate {
                 .processes()
                 .values()
                 .filter(|p| {
-                    // Skip ourselves
-                    if let Some(our) = our_pid {
-                        if p.pid() == our {
-                            return false;
-                        }
+                    // Skip ourselves and launcher ancestors
+                    if excluded_pids.contains(&p.pid()) {
+                        return false;
                     }
 
                     let name = p.name().to_string_lossy().to_lowercase();


### PR DESCRIPTION
## Summary

Fixes #5. `zenbench self-compare` was causing the child benchmark to wait up to 30s per round because `wait_for_no_benchmarks()` detected the parent `zenbench` CLI process as another benchmark.

- `run_bench_in_dir` now sets `ZENBENCH_LAUNCHER_PIDS` env var with the parent's PID
- `wait_for_no_benchmarks()` reads this and excludes those PIDs from the process scan
- The env var chains through nested launches (comma-separated append)
- Cross-platform: `sysinfo::Pid` accepts `usize` on all targets; env var inheritance is standard

## Test plan

- [ ] `cargo test --lib` passes (109 tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `zenbench self-compare --bench sorting --cargo-args='-- --group=overhead'` completes without "waiting for 1 other benchmark process(es)" spam
- [ ] Verify on macOS and Windows (env var inheritance + sysinfo PID parsing)