### PR TITLE
docs(zenbench): fix non-compiling sort_by_speed example + document the significance/regression rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Changed
 - Extended `exclude` in `Cargo.toml` to drop `.gitignore`, `benches/`, `tests/`, `docs/`, `site/`, and `CHART-GALLERY.md` from the published tarball; declarations and local builds are unaffected.
 
+### Fixed
+- docs(readme): fix non-compiling `sort_by_speed` example (`g.sort_by_speed()` → `g.config().sort_by_speed(true)`; the no-arg form is criterion-compat only) and document the significance rule (95% CI excludes zero **and** above the timer-resolution floor), the regression-gate's significance-gating (`--max-regression=N` fails only on a `>N%` slowdown that's also t-test significant), DCE/`black_box` guidance (returning the value defeats DCE), and throughput per-call semantics — gaps found by an insulated external-developer usability test (#docfix-zenbench-readme).
+
 ## [0.1.8] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ zenbench::main!(bench_sort);
 # After merging to main — save a baseline
 cargo bench -- --save-baseline=main
 
-# On PRs — check for regressions (exits 1 if > 5% slower)
+# On PRs — check for regressions (exits 1 on a >5% slowdown that's also
+# statistically significant; see "CI regression gate semantics" below)
 cargo bench -- --baseline=main
 
 # Auto-update baseline on clean runs
@@ -181,7 +182,7 @@ suite.group("dispatch", |g| {
     g.bench("StopToken", |b| b.iter(|| check_token()));
 
     g.baseline("impl Stop (Stopper)");
-    g.sort_by_speed();
+    g.config().sort_by_speed(true); // native API; the no-arg sort_by_speed() is criterion-compat only
 });
 ```
 
@@ -200,6 +201,86 @@ suite.group("dispatch", |g| {
   StopToken            ████████████ 1.03G
   &dyn Stop            ██████████ 889M
 ```
+
+## How to read an A/B result
+
+The `95% CI vs base` column is the bootstrap 95% confidence interval for the
+candidate's change against the group `baseline`, shown as `[lo% .. hi%]`
+(negative = candidate is faster). The baseline row itself shows `[lo .. hi]ns`.
+
+**When is a difference "significant"?** A change is reported significant only
+when **both** of these hold:
+
+1. The 95% CI excludes zero — i.e. `[lo .. hi]` does not straddle 0 (when a
+   `noise_threshold` is set, the CI must clear ±threshold of the baseline, not
+   just 0).
+2. The difference is **above the timer's quantization floor**. If the
+   per-iteration difference is smaller than ~2× what the hardware timer can
+   resolve, significance is forced to `false` regardless of the CI.
+
+So a CI that excludes zero is **necessary but not sufficient** — a result like
+`ci=[-1.33% .. -0.48%]` can still report `significant=false` when the absolute
+difference is below the timer resolution (this is the "resolution-limited"
+case). The significance test runs on the absolute per-iteration nanosecond CI;
+the percentages in the table are that same CI divided by the baseline mean.
+
+zenbench does **not** add a separate p-value cutoff here — the Wilcoxon
+p-value and Cohen's d are reported alongside, but the significance flag is
+CI-plus-timer-floor as described above.
+
+**Footnotes** flag results you should not over-read:
+
+- `[N] CI [lo% .. hi%] crosses zero — cannot confirm a difference` — the change
+  is **not** significant: the interval straddles zero, so the sign of the
+  change is unresolved. Treat it as noise, not a real win or regression.
+- `[N] real but tiny (effect 0.NN) — unlikely to matter` — significant, but
+  Cohen's d < 0.2, so the effect is too small to care about.
+- Drift / high-CV / sub-ns / near-timer-resolution footnotes flag noisy or
+  unmeasurable conditions; rerun on a quieter machine before trusting them.
+
+## CI regression gate semantics
+
+`--max-regression=N` is **significance-gated**, not a raw percentage cutoff. A
+benchmark fails the gate (counts as a regression, exit code 1) only when it is
+**both**:
+
+- more than `N%` slower than the saved baseline, **and**
+- statistically significant — a pooled two-sample t-test on the baseline-vs-new
+  samples gives `t > 2.0` (≈ p < 0.05). With < 2 samples per side, or zero
+  variance, the percentage alone decides.
+
+This means a noisy `+10%` swing on a loaded CI runner can **pass** the gate if
+the variance is high enough that the t-test can't confirm it — by design, so
+flaky runners don't fail your build on noise. If you need a hard percentage
+ceiling that ignores significance, gate on the raw `pct_change` in the CSV/JSON
+output yourself rather than relying on `--max-regression`.
+
+## Don't accidentally measure nothing
+
+`iter` and `with_input(...).run(...)` automatically pass the closure's return
+value (and `run`'s input) through `black_box`, so **returning the result of
+your work from the closure is what defeats dead-code elimination** — the
+compiler can't prove the value is unused. If your closure returns `()` and the
+work has no observable effect, the optimizer can delete it and you'll measure
+an empty loop (watch for the `sub-ns with near-zero variance — likely
+optimized away` footnote).
+
+Return the value when you can. When you can't (the work is a side effect, or
+you want to block a specific input from being const-folded), wrap it explicitly
+with `zenbench::black_box` (also in the prelude) or `std::hint::black_box`:
+
+```rust,ignore
+g.bench("hashes", |b| b.iter(|| compute_hash(&data)));        // returns → black_boxed for you
+g.bench("in_place", |b| b.iter(|| { sort_in_place(&mut buf); black_box(&buf); }));
+```
+
+## Throughput is per call
+
+`Throughput::Bytes(N)` / `Throughput::Elements(N)` declare the work done by a
+**single** `iter`/`run` invocation — per call, not per round or per sample.
+Reported throughput is `N / mean_time_per_call`. If one `b.iter(|| ...)`
+compresses a 64 KiB block, set `Throughput::Bytes(64 * 1024)`; the reported
+`GiB/s` is then bytes-per-call ÷ the mean per-call time.
 
 ## Migrating from criterion
 


### PR DESCRIPTION
An "insulated external developer" usability test — given **only** zenbench's README — built and ran a real A/B comparison and surfaced concrete documentation gaps, including a README example that does **not** compile. This fixes the README; every claim was verified against `src/`.

## What was wrong

1. **Non-compiling example (E0599).** The "Subgroups and organization" example called `g.sort_by_speed();` on a `BenchGroup`, which has no such method — the no-arg `sort_by_speed()` exists only on the `criterion_compat` group (`src/criterion_compat.rs:257`). The native form is `g.config().sort_by_speed(true)` (`GroupConfig::sort_by_speed`, `src/bench.rs:717`). Fixed.

2. **Significance rule was undocumented and the obvious reading is wrong.** The tester saw `ci=[-1.33% .. -0.48%]` (excludes zero) reported `significant=false`. Significance is **not** "CI excludes zero" alone: `PairedAnalysis::compute_with_config` (`src/stats.rs:387-402`) forces `significant=false` when the per-iteration difference is below ~2× the timer-resolution floor (`resolution_limited`), and requires the CI to clear ±`noise_threshold` when one is set. Added a "How to read an A/B result" section stating the exact rule and what the `[N] CI [..] crosses zero — cannot confirm a difference` footnote means (`src/report.rs:454`).

3. **`--max-regression=N` is significance-gated, not a raw %.** A `+10%` regression can PASS the gate. `compare_against_baseline` (`src/baseline.rs:246`) only flags `regressed = pct_change > max_regression_pct && statistically_significant`, where significance is a pooled t-test with `t > 2.0` (`src/baseline.rs:234-244`). The README said "exits 1 if >5% slower" (implies a raw percentage). Documented the real two-part gate and corrected the inline comment.

4. **No DCE/`black_box` guidance.** `Bencher::iter` / `with_input().run()` already pass the closure's return value (and `run`'s input) through `black_box` (`src/bench.rs:887`, :907/:1098), so **returning the result defeats dead-code elimination**; zenbench also re-exports `black_box` (`src/lib.rs:162`, in the prelude). Added a "Don't accidentally measure nothing" note.

5. **Throughput semantics.** `Throughput::Bytes/Elements(N)` is the work per **single** `iter`/`run` call (per-call), not per-round: `Throughput::compute` divides `N` by the per-iteration mean (`src/bench.rs:23-52`; per-iteration normalization at `src/stats.rs:319-329`). Added a "Throughput is per call" clarification.

## Notes

- README is doctest-wired via `#![doc = include_str!("../README.md")]` (`src/lib.rs:12`); `cargo test --doc` passes (the fixed snippet is `rust,ignore`; the only compiled `rust,no_run` block was already correct). The `sort_by_speed` fix was required regardless.
- Docs-only; no code or public-API changes.

Found via insulated external-developer test.